### PR TITLE
Allow null return value in aspect method

### DIFF
--- a/Classes/Aspects/AssetServiceAspect.php
+++ b/Classes/Aspects/AssetServiceAspect.php
@@ -18,7 +18,7 @@ class AssetServiceAspect
     /**
      * @Flow\Around("method(Neos\Media\Domain\Service\AssetService->getThumbnailUriAndSizeForAsset())")
      */
-    public function getThumbnailUriAndSizeForAssetAspect(JoinPointInterface $joinPoint): array
+    public function getThumbnailUriAndSizeForAssetAspect(JoinPointInterface $joinPoint): ?array
     {
         /** @var AssetInterface $asset */
         $asset = $joinPoint->getMethodArgument('asset');


### PR DESCRIPTION
The original method of the Neos Media AssetService can return null; thus, the aspect method should allow null as return value, too.